### PR TITLE
Support for scope query parameter in getOAuthRequestToken()

### DIFF
--- a/Controller/Component/OauthComponent.php
+++ b/Controller/Component/OauthComponent.php
@@ -201,6 +201,11 @@ class OauthComponent extends Component {
 				'oauth_callback' => $oAuthCallback,
 			),
 		));
+
+		if (!empty($this->_config[$this->useDbConfig]['scope'])) {
+			$request['uri']['query'] = array('scope' => $this->_config[$this->useDbConfig]['scope']);
+		}
+
 		App::uses('HttpSocketOauth', 'HttpSocketOauth.Lib');
 		$Http = new HttpSocketOauth();
 		$response = $Http->request($request);


### PR DESCRIPTION
LinkedIn supports a scope query parameter for granting member permissions.

https://developer.linkedin.com/documents/authentication#granting
