### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/Integration.md
+++ b/Integration.md
@@ -1,4 +1,4 @@
-#Integration Guide for Copula v0.1
+# Integration Guide for Copula v0.1
 
 Introduction by way of Disclaimer:
 
@@ -70,7 +70,7 @@ An example is given below:
 	);
 ```
 
-####Database Array Keys
+#### Database Array Keys
 
 <dl>
 <dt><b><code>datasource</code></b></dt>

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ![Copula logo](http://img.photobucket.com/albums/v295/Tenebrous/Copula/copula-logo_zps9cf00474.jpg)
-#Copula - bringing it all together
+# Copula - bringing it all together
 
 Copula is a CakePHP plugin for interacting with remote APIs like Facebook and Google. It takes care of all the boring details: you don't have to worry about connecting to the service or storing access tokens.
 
@@ -7,7 +7,7 @@ Copula is a CakePHP plugin for interacting with remote APIs like Facebook and Go
 
 Copula is, in itself, not very useful, and primarily aimed at developers.
 
-##Features
+## Features
 
 * Supports both OAuth and OAuth v2
 * Access tokens can be stored in the session, or persisted in your database
@@ -15,15 +15,15 @@ Copula is, in itself, not very useful, and primarily aimed at developers.
 
 In addition, Copula is well-tested, and working towards 100% code coverage.
 
-##Installation
+## Installation
 
 * Clone or download Copula to `app/Plugin/Copula`
 * Follow the [Integration Guide](https://github.com/CakePHP-Copula/Copula/blob/master/Integration.md)
 
-##Implementations
+## Implementations
 
 Copula has recently been rewritten and is necessarily incompatible with any plugins using previous versions. The code has been tested to work with Twitter (OAuth v1) and Google Cloud Print (OAuth v2). You may expect this section to be expanded shortly.
 
-##License
+## License
 
 Copula is &copy; Patrick Leahy and Dean Sofer. HttpSocketOAuth is &copy; Dean Sofer and Neil Crookes. All code is dual-licensed under both the MIT license and the GNU GPL version 2 or later.


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
